### PR TITLE
Add metrics for reserved gpu per task

### DIFF
--- a/common.go
+++ b/common.go
@@ -19,6 +19,7 @@ type (
 	resources struct {
 		CPUs  float64 `json:"cpus"`
 		Disk  float64 `json:"disk"`
+		GPUs  float64 `json:"gpus"`
 		Mem   float64 `json:"mem"`
 		Ports ranges  `json:"ports"`
 	}
@@ -357,4 +358,16 @@ func attributeString(attribute json.RawMessage) (string, error) {
 		return value, nil
 	}
 	return "", errDropAttribute
+}
+
+// Extract the application name by splitting the executor ID in two parts:
+// the application name (that can contain dots) and the UUID of the task
+// assigned by Mesos.
+func ExtractAppName(executorID string) string {
+	appNameComponents := strings.Split(executorID, ".")
+	if len(appNameComponents) <= 1 {
+		return executorID
+	} else {
+		return strings.Join(appNameComponents[:len(appNameComponents)-1], ".")
+	}
 }

--- a/slave_monitor.go
+++ b/slave_monitor.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"strings"
 )
 
 type (
@@ -231,18 +230,6 @@ func newSlaveMonitorCollector(httpClient *httpClient) prometheus.Collector {
 				labels, nil,
 			): metric{prometheus.CounterValue, func(s *statistics) float64 { return s.NetTxPackets }},
 		},
-	}
-}
-
-// Extract the application name by splitting the executor ID in two parts:
-// the application name (that can contain dots) and the UUID of the task
-// assigned by Mesos.
-func ExtractAppName(executorID string) string {
-	appNameComponents := strings.Split(executorID, ".")
-	if len(appNameComponents) <= 1 {
-		return executorID
-	} else {
-		return strings.Join(appNameComponents[:len(appNameComponents)-1], ".")
 	}
 }
 


### PR DESCRIPTION
GPU number per task fetched from the mesos slave state endpoint written in the same way as other metrics gathered from this endpoint. The ExtractAppName function was moved to common to be usable in slave_state.