### PR TITLE
Include number of xfs project ids total and used for slave metrics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ go:
 - "1.9.x"
 - "1.10.x"
 
+go_import_path: github.com/mesos/mesos_exporter
+
 script:
 - make

--- a/slave.go
+++ b/slave.go
@@ -548,6 +548,20 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
 			return nil
 		},
+		gauge("slave", "containerizer_xfs_project_ids", "Number of project IDs available for XFS isolator", "type"): func(m metricMap, c prometheus.Collector) error {
+			total, ok := m["containerizer/mesos/disk/project_ids_total"]
+			if !ok {
+				log.WithField("metric", "containerizer/mesos/disk/project_ids_total").Warn(LogErrNotFoundInMap)
+			}
+			free, ok := m["containerizer/mesos/disk/project_ids_free"]
+			if !ok {
+				log.WithField("metric", "containerizer/mesos/disk/project_ids_free").Warn(LogErrNotFoundInMap)
+			}
+			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(total - free)
+			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(free)
+			return nil
+		},
 
 		// END
 	}


### PR DESCRIPTION
In Meso 1.7.0 a new metric have been introduced for counting the total
number of XFS project IDs and the number of free items.